### PR TITLE
Implement issue #1: waitlist and auto-promotion for full activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -77,6 +77,10 @@ activities = {
     }
 }
 
+# Ensure every activity has a waitlist for overflow signups.
+for activity in activities.values():
+    activity.setdefault("waitlist", [])
+
 
 @app.get("/")
 def root():
@@ -105,9 +109,27 @@ def signup_for_activity(activity_name: str, email: str):
             detail="Student is already signed up"
         )
 
+    if email in activity["waitlist"]:
+        raise HTTPException(
+            status_code=400,
+            detail="Student is already on waitlist"
+        )
+
+    # Add student to waitlist when the activity is full.
+    if len(activity["participants"]) >= activity["max_participants"]:
+        activity["waitlist"].append(email)
+        return {
+            "message": f"{activity_name} is full. Added {email} to waitlist.",
+            "status": "waitlisted",
+            "waitlist_position": len(activity["waitlist"])
+        }
+
     # Add student
     activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+    return {
+        "message": f"Signed up {email} for {activity_name}",
+        "status": "enrolled"
+    }
 
 
 @app.delete("/activities/{activity_name}/unregister")
@@ -120,13 +142,28 @@ def unregister_from_activity(activity_name: str, email: str):
     # Get the specific activity
     activity = activities[activity_name]
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
+    if email in activity["participants"]:
+        activity["participants"].remove(email)
 
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+        # Promote first waitlisted student to participant.
+        promoted_student = None
+        if activity["waitlist"]:
+            promoted_student = activity["waitlist"].pop(0)
+            activity["participants"].append(promoted_student)
+
+        if promoted_student:
+            return {
+                "message": f"Unregistered {email} from {activity_name}. Promoted {promoted_student} from waitlist.",
+                "promoted_student": promoted_student
+            }
+
+        return {"message": f"Unregistered {email} from {activity_name}"}
+
+    if email in activity["waitlist"]:
+        activity["waitlist"].remove(email)
+        return {"message": f"Removed {email} from the waitlist for {activity_name}"}
+
+    raise HTTPException(
+        status_code=400,
+        detail="Student is neither enrolled nor on the waitlist for this activity"
+    )

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -12,6 +12,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML =
+        '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -20,6 +22,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft =
           details.max_participants - details.participants.length;
+        const waitlistCount = details.waitlist ? details.waitlist.length : 0;
 
         // Create participants HTML with delete icons instead of bullet points
         const participantsHTML =
@@ -37,13 +40,32 @@ document.addEventListener("DOMContentLoaded", () => {
             </div>`
             : `<p><em>No participants yet</em></p>`;
 
+        const waitlistHTML =
+          waitlistCount > 0
+            ? `<div class="waitlist-section">
+              <h5>Waitlist:</h5>
+              <ul class="waitlist-list">
+                ${details.waitlist
+                  .map(
+                    (email, index) =>
+                      `<li><span class="participant-email">#${
+                        index + 1
+                      } ${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                  )
+                  .join("")}
+              </ul>
+            </div>`
+            : "";
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <p><strong>Waitlist:</strong> ${waitlistCount} student(s)</p>
           <div class="participants-container">
             ${participantsHTML}
+            ${waitlistHTML}
           </div>
         `;
 
@@ -131,7 +153,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       if (response.ok) {
         messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        messageDiv.className =
+          result.status === "waitlisted" ? "info" : "success";
         signupForm.reset();
 
         // Refresh activities list to show updated participants

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -87,6 +87,29 @@ section h3 {
   font-size: 16px;
 }
 
+.waitlist-section {
+  margin-top: 12px;
+}
+
+.waitlist-section h5 {
+  margin-bottom: 8px;
+  color: #8a6d3b;
+  font-size: 16px;
+}
+
+.waitlist-section ul {
+  list-style-type: none;
+  padding-left: 5px;
+}
+
+.waitlist-section ul li {
+  padding: 4px 0;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .participants-section ul {
   list-style-type: none;
   padding-left: 5px;


### PR DESCRIPTION
## Summary
Implements issue #1 by adding waitlist behavior when activities are full and automatic promotion when an enrolled student unregisters.

## Changes
- Backend (`src/app.py`)
  - Added `waitlist` initialization for each activity.
  - Updated signup logic:
    - If activity has space, student is enrolled.
    - If full, student is added to waitlist with `status: waitlisted` and `waitlist_position`.
    - Prevents duplicate enroll/waitlist entries.
  - Updated unregister logic:
    - Removing enrolled student auto-promotes first waitlisted student (FIFO).
    - Supports removing a student directly from waitlist.
    - Added clearer error for unknown student/activity relation.
- Frontend (`src/static/app.js`)
  - Shows waitlist count and waitlisted users per activity.
  - Distinguishes signup success messages (`enrolled`) from waitlist info messages (`waitlisted`).
  - Resets activity dropdown options correctly on refresh.
- Styling (`src/static/styles.css`)
  - Added styles for waitlist section display.

## Validation
Validated waitlist flow with Python snippet:
- full activity signup adds to waitlist
- unregister from participants promotes first waitlisted student
- waitlisted student can unregister from waitlist

## Related
Closes #1